### PR TITLE
Add support to specify multiple directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A script for MPV that automatically updates your AniList based on the file you j
 > - The file must have the episode number in it (absolute numbering should work)<br>
 > - In case of remakes, specify the year of the remake to ensure it updates the proper one<br>
 >
-> To avoid the script running and making useless API calls, you can set a directory in `main.lua`, where it will work
+> To avoid the script running and making useless API calls, you can set one or more directories in `main.lua`, where it will work
 
 For any issues, you can either open an issue on here, or message me on discord (azuredblue)
 
@@ -70,6 +70,18 @@ end)
 
 mp.add_key_binding('ctrl+d', 'open_folder', open_folder)
 ```
+
+### Specifying Directories
+
+To limit the script to only work on files in certain directories, open `main.lua` and set the `DIRECTORIES` table near the top of the file. For example:
+
+```lua
+DIRECTORIES = {"D:/Torrents", "D:/Anime"}
+```
+
+- If you leave the table empty (`DIRECTORIES = {}`), the script will work for every video you watch with mpv.
+- If you specify one or more directories, the script will only trigger for files whose path starts with any of those directories.
+- **Note:** Restricting directories only prevents the script from automatically updating AniList for files outside the specified directories. Manual actions using the keybinds (Ctrl+A, Ctrl+B, Ctrl+D) will still work for any file, regardless of its location.
 
 ## How It Works
 

--- a/anilistUpdater/main.lua
+++ b/anilistUpdater/main.lua
@@ -1,12 +1,19 @@
 local utils = require 'mp.utils'
 
--- The directory the script will work on
--- Leaving it blank will make it work on every video you watch with mpv
+-- The directories the script will work on
+-- Specify as a table of strings. Leaving it empty will make it work on every video you watch with mpv
 -- You can still update manually via Ctrl+A
--- Setting a directory will only work if the path of the video contains this directory
-DIRECTORY = ""
+-- Example: DIRECTORIES = {"D:/Torrents", "D:/Anime"}
+DIRECTORIES = {}
 
--- Example: DIRECTORY = "D:/Torrents" or "D:/Anime"
+local function path_starts_with_any(path, directories)
+    for _, dir in ipairs(directories) do
+        if path:sub(1, #dir) == dir then
+            return true
+        end
+    end
+    return false
+end
 
 function callback(success, result, error)
     if result.status == 0 then
@@ -66,18 +73,17 @@ mp.observe_property("percent-pos", "number", check_progress)
 -- Reset triggered
 mp.register_event("file-loaded", function()
     triggered = false
-    if DIRECTORY ~= "" then
+    if #DIRECTORIES > 0 then
         local directory = mp.get_property("working-directory")
         directory = (directory:sub(-1) == '/' or directory:sub(-1) == '\\') and directory or directory .. '/'
         local file_path = mp.get_property("path")
         local path = utils.join_path(directory, file_path)
         path = path:gsub("\\", "/")
-        
-        if string.find(path, DIRECTORY) ~= 1 then
+
+        if not path_starts_with_any(path, DIRECTORIES) then
             mp.unobserve_property(check_progress)
         end
     end
-    
 end)
 
 -- Keybinds, modify as you please


### PR DESCRIPTION
- Updated the script to allow specifying multiple directories in the `DIRECTORIES` table in `main.lua`.
- The script now checks if the video file path starts with any of the specified directories.
- Updated the README for the new `DIRECTORIES` usage.