### PR TITLE
feat: Add automatic anime update function with enable/disable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ SET_TO_COMPLETED_AFTER_LAST_EPISODE_CURRENT=yes
 SET_TO_COMPLETED_AFTER_LAST_EPISODE_REWATCHING=yes
 ADD_ENTRY_IF_MISSING=no
 SILENT_MODE=no
+ENABLE_AUTOMATIC_UPDATES=yes
 ```
 
 #### Option Descriptions
@@ -90,6 +91,7 @@ SILENT_MODE=no
 - **SET_TO_COMPLETED_AFTER_LAST_EPISODE_REWATCHING**: `yes`/`no`. If `yes`, set to COMPLETED after last episode if status was REPEATING (rewatching). Default is `yes`.
 - **ADD_ENTRY_IF_MISSING**: `yes`/`no`. If `yes`, automatically add anime to your list if it's not found in your list during search. Default is `no`. **⚠️ Warning: This can add incorrect anime to your list if the detection is inaccurate.**
 - **SILENT_MODE**: `yes`/`no`. If `yes`, won't show OSD messages. Default is `no`.
+- **ENABLE_AUTOMATIC_UPDATES**: `yes`/`no`. If yes, automatically updates anime progress on Anilist after reaching the configured completion percentage (e.g., 85%). If no, disables automatic updates and only allows manual updates via keybindings. Default is yes.
 
 > [!NOTE]
 > All boolean options must be `yes` or `no` (not `true`/`false`).

--- a/main.lua
+++ b/main.lua
@@ -18,6 +18,8 @@ SET_TO_COMPLETED_AFTER_LAST_EPISODE_REWATCHING: Boolean. If true, set to COMPLET
 ADD_ENTRY_IF_MISSING: Boolean. If true, automatically add anime to your list if it's not found during search. Default is false.
 
 SILENT_MODE: Boolean. If true, won't show OSD messages.
+
+ENABLE_AUTOMATIC_UPDATES: Boolean. If false, automatic updates are disabled and only manual updates via keybindings work. Default is true.
 ]]
 
 local utils = require 'mp.utils'
@@ -74,6 +76,7 @@ SET_TO_COMPLETED_AFTER_LAST_EPISODE_CURRENT=yes
 SET_TO_COMPLETED_AFTER_LAST_EPISODE_REWATCHING=yes
 ADD_ENTRY_IF_MISSING=no
 SILENT_MODE=no
+ENABLE_AUTOMATIC_UPDATES=yes
 ]]
 
 -- Try script-opts directory (sibling to scripts)
@@ -143,7 +146,8 @@ local options = {
     SET_TO_COMPLETED_AFTER_LAST_EPISODE_CURRENT = true,
     SET_TO_COMPLETED_AFTER_LAST_EPISODE_REWATCHING = true,
     ADD_ENTRY_IF_MISSING = false,
-    SILENT_MODE = false
+    SILENT_MODE = false,
+    ENABLE_AUTOMATIC_UPDATES = true
 }
 
 -- Override defaults with values from config file
@@ -285,11 +289,13 @@ progress_timer:stop()
 -- Handle pause/unpause events to control the timer
 function on_pause_change(name, value)
     isPaused = value
-    if value then
-        progress_timer:stop()
-    else
-        if not triggered then
-            progress_timer:resume()
+    if options.ENABLE_AUTOMATIC_UPDATES then
+        if value then
+            progress_timer:stop()
+        else
+            if not triggered then
+                progress_timer:resume()
+            end
         end
     end
 end
@@ -316,6 +322,10 @@ mp.observe_property("pause", "bool", on_pause_change)
 mp.register_event("file-loaded", function()
     triggered = false
     progress_timer:stop()
+
+    if not options.ENABLE_AUTOMATIC_UPDATES then
+        return
+    end
 
     if not is_ani_cli_compatible() and #DIRECTORIES > 0 then
         local path = get_path()


### PR DESCRIPTION
**Description**
A new configuration option, ENABLE_AUTOMATIC_UPDATES, allows users to enable or disable this behavior, providing flexibility between automatic and manual updates.

**New Option**
ENABLE_AUTOMATIC_UPDATES: yes/no. If yes, automatically updates anime progress on Anilist after reaching the configured completion percentage (e.g., 85%). If no, disables automatic updates and only allows manual updates via keybindings. Default is yes.

**How It Works**
When playback reaches UPDATE_PERCENTAGE (default: 85%), the script triggers an update to Anilist.
Automatic updates only occur if:
ENABLE_AUTOMATIC_UPDATES=yes
If disabled (no):
No automatic updates are triggered
Users can still update manually via keybindings

DIRECTORIES=
EXCLUDED_DIRECTORIES=
UPDATE_PERCENTAGE=85
SET_COMPLETED_TO_REWATCHING_ON_FIRST_EPISODE=no
UPDATE_PROGRESS_WHEN_REWATCHING=yes
SET_TO_COMPLETED_AFTER_LAST_EPISODE_CURRENT=yes
SET_TO_COMPLETED_AFTER_LAST_EPISODE_REWATCHING=yes
ADD_ENTRY_IF_MISSING=no
SILENT_MODE=no
**ENABLE_AUTOMATIC_UPDATES=yes**

**Motivation**
- Prevents unwanted updates when anime titles are incorrectly detected
- Avoids repeated OSD error messages in such cases
- Gives users full control over update behavior
- Improves usability for mixed or unstructured media libraries

_**I also updated the readme for reference.**_