### PR TITLE
Use wl-paste on systems with Wayland

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -533,6 +533,8 @@ local function paste_clipboard_to_field()
         args = {"powershell", "-NoProfile", "-Command", "Get-Clipboard -Raw"}
     elseif os.getenv("OSTYPE") == "darwin" then
         args = {"pbpaste"}
+    elseif os.getenv("XDG_SESSION_TYPE") == "wayland" then
+        args = {"wl-paste"}
     else
         args = {"xclip", "-selection", "clipboard", "-o"}
     end


### PR DESCRIPTION
xclip does not work on system using Wayland. You can easily achieve the same by using wl-paste. Check $XDG_SESSION_TYPE to see if we use a Wayland session and use wl-paste accordingly.